### PR TITLE
issue 178 team picture margin fix

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -48,6 +48,10 @@
   max-width: 250px;
 }
 
+.team-member h3 {
+  margin-top: 25px;
+}
+
 .team-member p {
   font-size: 0.85em;
   color: rgb(116, 115, 115);
@@ -55,7 +59,7 @@
 
 .team-member img {
   border-radius: 50%;
-  box-shadow: 0 0 30px 15px white;
+  box-shadow: 0 0 15px 7px white;
 }
 
 .team-member img:hover {


### PR DESCRIPTION
**Fixes # 178:** < https://github.com/zero-to-mastery/Keiko-Corp/issues/178 >

fixes margin between team picture and name.
drops box shadow a bit to avoid overlapping

