### PR TITLE
Add keyboard accessibility for dark/light theme switch. Switch can be…

### DIFF
--- a/assets/css/nav-styles.css
+++ b/assets/css/nav-styles.css
@@ -119,7 +119,7 @@
 }
 
 input {
-  display: none;
+  opacity: 0;
 }
 
 .toggle-container {
@@ -131,6 +131,10 @@ input {
   border-radius: 50px;
   background: #f4f6ff;
   transition: transform 0.5s;
+}
+
+input:focus + .toggle-container {
+  box-shadow: var(--focusShadow);
 }
 
 input:checked ~ .toggle-container {

--- a/assets/global.css
+++ b/assets/global.css
@@ -66,10 +66,10 @@ body {
   --transition: 0.2s all ease-in;
 
   /* shadows */
-  --smShadow: box-shadow: 0px 4px 6px -1px rgba(0, 0, 0, 0.25);
-  --mdShadow: box-shadow: 0px 10px 15px -3px rgba(0, 0, 0, 0.25);
-  --lgShadow: box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-  --focusShadow: box-shadow: 0 0 0 3px #1f014d2f;
+  --smShadow: 0px 4px 6px -1px rgba(0, 0, 0, 0.25);
+  --mdShadow: 0px 10px 15px -3px rgba(0, 0, 0, 0.25);
+  --lgShadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  --focusShadow: 0 0 0 3px #1f014d2f;
 
   /* breakpoints */
   --sm: 640px


### PR DESCRIPTION
… accessed by using tab. Switch can be toggled by pressing space. Css variables for shadows in the global.css file needed the box-shadow property to be removed, so they could be used for applying focusShadow style.

# Pull Request Template

> Please provide all of the details below. Pull requests missing any of the information below will be closed!
> Providing the issue number/url helps us identify the problem being solved and keep the issues tab clean and tidy

#### **What issue does this fix?**
Add keyboard accessibility for dark/light theme switch.
- Switch gets focus on tab.
- Switch can be toggled using space key.
- Used css variable for focusShadow to apply focus style. 

Summarize what this PR fixes:-

#### **What issue is it attached to?**

Fixes #472 

#### **Checklist**

(Add an `x` between the brackets to check the items)

- [x] I have summarized what this PR fixes above
- [x] I have provided the issue ID/URL above
- [x] I have not added Bootstrap or jQuery and used correct styling guide.
- [x] This PR fixes only the issue mentioned above (create separate PRs for separate issues)
- [x] I was the first one to claim the issue or I created the issue
