### PR TITLE
Fixes pricing-section button issue #887

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -970,6 +970,11 @@ p {
   margin-bottom: var(--lgPadding);
 }
 
+[data-theme='dark'] .price-card .red-btn {
+  background-color: var(--primar-color);
+  color: #fff;
+}
+
 .price-card .red-btn:hover {
   color: var(--text);
   background-color: var(--lightBlue);


### PR DESCRIPTION
# Pull Request Template

Summarize what this PR fixes:-

In the figma designs, and in the pricing section, the "sign up" buttons are grey (dark mode). On the actual website, the buttons stay a constant white. I changed the color so that on dark theme, they turn grey instead of staying white.

Fixes #887 

#### **Checklist**

(Add an `x` between the brackets to check the items)

- [x] I have summarize what this PR fixes above
- [x] I have provided the issue ID/URL above
- [x] I have not added Bootstrap or jQuery and used correct styling guide.
- [x] This PR fixes only the issue mentioned above (create separate PRs for separate issues)
- [x] I was the first one to claim the issue or I created the issue - I created the issue
