### PR TITLE
added the correct background color to the pricing section

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -43,7 +43,7 @@ body {
   --heroText: #343A40;
   --toggleBackground: #20014d;
   /* Added a custom property for the darktheme button background*/
-  --pricingBackground: #fff;
+  --pricingBackground: #F4F7FE;
 
   /* text sizes */
   --smText: 0.64rem;


### PR DESCRIPTION
The pricing section had the same color (white) as the footer. It didn't have any contrast. Updated the pricing background color to the color indicated in figma.